### PR TITLE
プルダウンが要素の上に表示される条件を修正した

### DIFF
--- a/src/auto-complete.directive.ts
+++ b/src/auto-complete.directive.ts
@@ -254,10 +254,17 @@ export class NguiAutoCompleteDirective implements OnInit, OnChanges {
     if (this.componentRef) {
       let component = this.componentRef.instance;
 
+      let scrollheight = 0;
+      if (this.source && this.source.length > 0) {
+        scrollheight = this.source.length * 24;  // プルダウンのoption1つのheightが24px
+        scrollheight = scrollheight > 300 ? 300 : scrollheight;  // 300以上は300にする
+      }
+      scrollheight += 50;  // フッターがあるかもしれないので、フッター分のオフセットを加味する
+
       /* setting width/height auto complete */
       let thisElBCR = this.el.getBoundingClientRect();
       let thisInputElBCR = this.inputEl.getBoundingClientRect();
-      let closeToBottom = thisInputElBCR.bottom + 100 > window.innerHeight;
+      let closeToBottom = thisInputElBCR.bottom + scrollheight > window.innerHeight;
       let directionOfStyle = this.isRtl ? 'right' : 'left';
 
       this.acDropdownEl.style.width = thisInputElBCR.width + "px";


### PR DESCRIPTION
# 対応内容
- 要素の下に、展開するプルダウンのscrollheight + 50pxの画面に余裕がない場合、プルダウンをtop表示するように計算処理を修正した
（この処理が実行されるタイミングではデータバインドがまだなので、scrollheightが簡単に取得できそうになく、要素数をもとに高さを算出するようにした）

# テスト
![image](https://user-images.githubusercontent.com/17742806/78211364-b3247600-74e7-11ea-86c9-6607089df4f9.png)
![image](https://user-images.githubusercontent.com/17742806/78211376-bc154780-74e7-11ea-8c67-4d6f1428baf7.png)
